### PR TITLE
Workaround to use this role from a molecule driver

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge.yml

--- a/molecule/os_delivery_not_found/molecule.yml
+++ b/molecule/os_delivery_not_found/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: "molecule-converge-notest" 
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml
@@ -46,3 +48,19 @@ verifier:
   directory: ../resources/tests_err/
   additional_files_or_dirs: 
     - ../tests/test_os.py
+
+scenario:
+  test_sequence:
+    #- dependency
+    - lint
+    - cleanup
+    - destroy
+    #- syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    #- side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/os_double_repo/molecule.yml
+++ b/molecule/os_double_repo/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml
@@ -46,3 +48,19 @@ verifier:
   directory: ../resources/tests_err/
   additional_files_or_dirs: 
     - ../tests/test_os.py
+
+scenario:
+  test_sequence:
+    #- dependency
+    - lint
+    - cleanup
+    - destroy
+    #- syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    #- side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/os_double_sdcard/molecule.yml
+++ b/molecule/os_double_sdcard/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml
@@ -45,3 +47,19 @@ verifier:
   options:
     v: true
   directory: ../resources/tests_err/
+
+scenario:
+  test_sequence:
+    #- dependency
+    - lint
+    - cleanup
+    - destroy
+    #- syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    #- side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/os_dwl_failed_missing_file/molecule.yml
+++ b/molecule/os_dwl_failed_missing_file/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml

--- a/molecule/os_dwl_failed_missing_tar/molecule.yml
+++ b/molecule/os_dwl_failed_missing_tar/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml

--- a/molecule/os_dwl_failed_wrong_marketing_tar/molecule.yml
+++ b/molecule/os_dwl_failed_wrong_marketing_tar/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml

--- a/molecule/os_dwl_light/molecule.yml
+++ b/molecule/os_dwl_light/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge.yml

--- a/molecule/os_dwl_specific_date/molecule.yml
+++ b/molecule/os_dwl_specific_date/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge.yml

--- a/molecule/os_name_not_found/molecule.yml
+++ b/molecule/os_name_not_found/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml
@@ -45,3 +47,19 @@ verifier:
   directory: ../resources/tests_err/
   additional_files_or_dirs: 
     - ../tests/test_os.py
+
+scenario:
+  test_sequence:
+    #- dependency
+    - lint
+    - cleanup
+    - destroy
+    #- syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    #- side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/os_repo_wrong_descriptor/molecule.yml
+++ b/molecule/os_repo_wrong_descriptor/molecule.yml
@@ -15,6 +15,8 @@ lint: |
   flake8    
 provisioner:
   name: ansible
+  options:
+    skip-tags: molecule-converge-notest
   playbooks:
     prepare: ../resources/prepare.yml
     converge: ../resources/converge_catch.yml
@@ -44,3 +46,19 @@ verifier:
   directory: tests/
   additional_files_or_dirs: 
     - ../../resources/tests/test_os.py
+
+scenario:
+  test_sequence:
+    #- dependency
+    - lint
+    - cleanup
+    - destroy
+    #- syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    #- side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/resources/converge_catch.yml
+++ b/molecule/resources/converge_catch.yml
@@ -29,17 +29,17 @@
         - name: Define item variable to can use ansible_failed_task (linked to ansible issue 57399)
           set_fact:
             item: {attribute: "os_info", dest: "_"}
-        
+
         - name: Save Failure Information To Manage them from verify step
-          copy: 
+          copy:
             content: '{"task_name": "{{ ansible_failed_task.name }}", "return": {{ ansible_failed_result }} }'
             dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/failure_{{ inventory_hostname }}.json"
-          when: (test_failure_from_converge is not defined) or (test_failure_from_converge == False)
+          when: (test_failure_from_converge is not defined) or (not test_failure_from_converge)
           changed_when: "'molecule-idempotence-notest' not in ansible_skip_tags"
           delegate_to: localhost
-        
+
         - name: Test Failure Task Name From Converge
-          assert: 
+          assert:
             that: ansible_failed_task.name == waited_failed_task_name
             fail_msg: "Catched Failing task '{{ ansible_failed_task.name }}' is not the waited one {{ waited_failed_task_name }}."
             success_msg: "Failed Task is the waited one"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     fstype: vfat
     state: mounted
     boot: no
-  tags: notest
+  tags: molecule-converge-notest
 
 - name: Get Latest Release Date information from repository for OS {{ requested_os_name }}
   block:
@@ -60,5 +60,4 @@
     reboot_timeout: 1200
     pre_reboot_delay: 0
     post_reboot_delay: 30
-  tags: notest
-  
+  tags: molecule-converge-notest

--- a/tests/inventory.yml
+++ b/tests/inventory.yml
@@ -5,4 +5,3 @@ rpi:
       ansible_user: "{{ lookup('env','RPI_TEST_SSH_USER')|default('pi') }}"
       ansible_password: "{{ lookup('env','RPI_TEST_SSH_PASSWORD')|default('raspberry') }}"
       #ansible_ssh_extra_args: '-o StrictHostKeyChecking=no -o userknownhostsfile=/dev/null'
-


### PR DESCRIPTION
workaround molecule bug ansible-community/molecule#2992

Use specific notest tag : molecule-converge-notest
With this, it is now temporary impossible to make idempotence test on error case.
(and this is not so usefull)

close #3 
